### PR TITLE
🚑 Fix permissions section to major release tag workflow

### DIFF
--- a/.github/workflows/major-release-tag.yml
+++ b/.github/workflows/major-release-tag.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [created]
 
+permissions:
+  contents: write
+
 jobs:
   movetag:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration in `.github/workflows/major-release-tag.yml` to include permissions for writing to repository contents.

Workflow configuration update:

* [`.github/workflows/major-release-tag.yml`](diffhunk://#diff-795a65b943556d553e886118695447d90fb4b97dc6117b9c5b74d77a69ed77fbR7-R9): Added `permissions` with `contents: write` to ensure the workflow has the necessary permissions to modify repository contents during execution.